### PR TITLE
Handle product defaults in ProductProvider

### DIFF
--- a/components/product/product-context.tsx
+++ b/components/product/product-context.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter, useSearchParams } from 'next/navigation';
 import React, { createContext, useContext, useMemo, useOptimistic } from 'react';
+import { Product } from 'lib/shopify/types';
 
 type ProductState = {
   [key: string]: string;
@@ -17,13 +18,42 @@ type ProductContextType = {
 
 const ProductContext = createContext<ProductContextType | undefined>(undefined);
 
-export function ProductProvider({ children }: { children: React.ReactNode }) {
+export function ProductProvider({
+  children,
+  product
+}: {
+  children: React.ReactNode;
+  product?: Product;
+}) {
   const searchParams = useSearchParams();
 
   const getInitialState = () => {
     const params: ProductState = {};
     for (const [key, value] of searchParams.entries()) {
       params[key] = value;
+    }
+
+    if (product) {
+      const lowercaseParamKeys = Object.keys(params);
+
+      product.options.forEach((option) => {
+        const optionKey = option.name.toLowerCase();
+
+        if (!lowercaseParamKeys.includes(optionKey) && option.values.length === 1) {
+          params[optionKey] = option.values[0];
+        }
+      });
+
+      const fallbackVariant =
+        product.variants.find((variant) => variant.availableForSale) || product.variants[0];
+
+      fallbackVariant?.selectedOptions.forEach((selectedOption) => {
+        const optionKey = selectedOption.name.toLowerCase();
+
+        if (!lowercaseParamKeys.includes(optionKey)) {
+          params[optionKey] = selectedOption.value;
+        }
+      });
     }
     return params;
   };


### PR DESCRIPTION
## Summary
- allow ProductProvider to accept an optional product prop
- seed initial product state with defaults from options and available variants when URL params are absent

## Testing
- pnpm test *(fails due to existing Prettier formatting warnings in the repository)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f6c1f91c4832fb509ca929c9fde4b)